### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cgroup-v1:
-    uses: trfore/docker-image/.github/workflows/test_systemd.yml@main
-    with:
-      continue-on-error: true
-      runner: ubuntu-20.04
-      volume-permission: ro
-
   cgroup-v2:
     uses: trfore/docker-image/.github/workflows/test_systemd.yml@main
     with:
@@ -31,14 +24,12 @@ jobs:
       volume-permission: rw
 
   check:
-    runs-on: ubuntu-latest
-    needs:
-      - cgroup-v1
-      - cgroup-v2
     if: success() || failure()
+    needs:
+      - cgroup-v2
+    runs-on: ubuntu-latest
     steps:
       - run: >-
           python -c "assert set([
-          '${{ needs.cgroup-v1.result }}',
           '${{ needs.cgroup-v2.result }}',
           ]) == {'success'}"


### PR DESCRIPTION
for rocky 9 and probably for rocky 10 I needed to drop cgroup v1 testing.

I am not sure if this also necessary for your images.